### PR TITLE
TargetRubyVersionを2.5に変更

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
 
 Style/StringLiterals:
   Enabled: true


### PR DESCRIPTION
To fix this error:
RuboCop found unsupported Ruby version 2.4 in `TargetRubyVersion` parameter (in .rubocop.yml). 2.4-compatible analysis was dropped after version 1.12.