### PR TITLE
都道府県コードの取得にて、切取対象が都道府県名になっていたため、地方公共団体コードに訂正

### DIFF
--- a/data/exporter.rb
+++ b/data/exporter.rb
@@ -41,7 +41,7 @@ module JpLocalGov
       def to_hash(items)
         @local_gov_hash[items[0]] = {
           code: items[0],
-          prefecture_code: items[1][0..1],
+          prefecture_code: items[0][0..1],
           prefecture: items[1],
           prefecture_kana: covert_half_char_to_full_char(items[3]),
           city: items[2],


### PR DESCRIPTION
## 目的

- 都道府県コードの取得にて、切取対象が都道府県名になっていたため、地方公共団体コードに訂正
    - 「東京都」：×「東京」→「01」