### PR TITLE
プロパティ指定での検索APIを作成

### DIFF
--- a/lib/jp_local_gov.rb
+++ b/lib/jp_local_gov.rb
@@ -43,7 +43,6 @@ module JpLocalGov
   end
 
   def query_builder(target, conditions)
-
     condition_stmt = conditions.map.with_index do |condition, index|
       value = condition[1].is_a?(String) ? "\"#{condition[1]}\"" : (condition[1]).to_s
       template = "#{target}[:#{condition[0]}] == #{value}"

--- a/lib/jp_local_gov.rb
+++ b/lib/jp_local_gov.rb
@@ -5,7 +5,7 @@ require_relative "jp_local_gov/local_gov"
 require "json"
 
 module JpLocalGov
-  DATA_DIR = "#{File.dirname(__FILE__)}/../data/json/"
+  DATA_DIR = "#{File.dirname(__FILE__)}/../data/json/".freeze
   CHECK_DIGITS_INDEX = 5
   CHECK_BASE = 11
 

--- a/lib/jp_local_gov.rb
+++ b/lib/jp_local_gov.rb
@@ -15,8 +15,8 @@ module JpLocalGov
     return nil unless local_gov_code.is_a?(String) && valid_code?(local_gov_code)
 
     json_file = "#{DATA_DIR}#{local_gov_code[0..1]}.json"
-    data = JSON.parse(File.open(json_file).read)
-    local_gov_data = data[local_gov_code]
+    data = JSON.parse(File.open(json_file).read, { symbolize_names: true })
+    local_gov_data = data[local_gov_code.to_sym]
     return nil if local_gov_data.nil?
 
     JpLocalGov::LocalGov.new(local_gov_data)

--- a/lib/jp_local_gov.rb
+++ b/lib/jp_local_gov.rb
@@ -22,6 +22,36 @@ module JpLocalGov
     JpLocalGov::LocalGov.new(local_gov_data)
   end
 
+  def where(conditions)
+    return nil unless conditions.is_a?(Hash)
+
+    json_files = [*1..47].map { format("%02<number>d", number: _1) }.map { "#{DATA_DIR}#{_1}.json" }
+    results = json_files.map do |json_file|
+      data = JSON.parse(File.open(json_file).read, { symbolize_names: true })
+      build_local_gov(data, conditions)
+    end.flatten.compact
+    return nil if results.empty?
+
+    results.one? ? results.first : results
+  end
+
+  def build_local_gov(data, conditions)
+    data.values
+        .select { |target| query_builder(target, conditions) }
+        .tap { |result| return nil if result.empty? }
+        .map { |result| JpLocalGov::LocalGov.new(result) }
+  end
+
+  def query_builder(target, conditions)
+
+    condition_stmt = conditions.map.with_index do |condition, index|
+      value = condition[1].is_a?(String) ? "\"#{condition[1]}\"" : (condition[1]).to_s
+      template = "#{target}[:#{condition[0]}] == #{value}"
+      index.zero? ? template : " && #{template}"
+    end.join
+    eval condition_stmt
+  end
+
   # Inspect code by check digits defined in JISX0402
   # https://www.soumu.go.jp/main_content/000137948.pdf
   def valid_code?(code)
@@ -34,6 +64,6 @@ module JpLocalGov
     code[CHECK_DIGITS_INDEX] == check_digits.to_s
   end
 
-  private_class_method :valid_code?
+  private_class_method :valid_code?, :build_local_gov, :query_builder
   private_constant :CHECK_DIGITS_INDEX, :CHECK_BASE
 end

--- a/lib/jp_local_gov/local_gov.rb
+++ b/lib/jp_local_gov/local_gov.rb
@@ -5,13 +5,13 @@ module JpLocalGov
     attr_reader :code, :prefecture_code, :prefecture, :prefecture_kana, :city, :city_kana, :prefecture_capital
 
     def initialize(data)
-      @code = data["code"]
-      @prefecture_code = data["prefecture_code"]
-      @prefecture = data["prefecture"]
-      @prefecture_kana = data["prefecture_kana"]
-      @city = data["city"]
-      @city_kana = data["city_kana"]
-      @prefecture_capital = data["prefecture_capital"]
+      @code = data[:code]
+      @prefecture_code = data[:prefecture_code]
+      @prefecture = data[:prefecture]
+      @prefecture_kana = data[:prefecture_kana]
+      @city = data[:city]
+      @city_kana = data[:city_kana]
+      @prefecture_capital = data[:prefecture_capital]
     end
   end
 end

--- a/spec/jp_local_gov_spec.rb
+++ b/spec/jp_local_gov_spec.rb
@@ -38,4 +38,105 @@ RSpec.describe JpLocalGov do
       end
     end
   end
+
+  describe ".where" do
+    context "only one condition is specified" do
+      subject(:result) { JpLocalGov.where(condition) }
+
+      context "when the only one result exists" do
+        let(:condition) { { city: "千代田区" } }
+        it "returns a single LocalGov record" do
+          expect(result.code).to eq("131016")
+          expect(result.prefecture_code).to eq("13")
+          expect(result.prefecture).to eq("東京都")
+          expect(result.prefecture_kana).to eq("トウキョウト")
+          expect(result.city).to eq("千代田区")
+          expect(result.city_kana).to eq("チヨダク")
+          expect(result.prefecture_capital).to be_falsey
+        end
+      end
+
+      context "when the several results exist" do
+        let(:condition) { { city: "森町" } }
+        it "returns Array includes several LocalGov record" do
+          expect(result).to be_a_kind_of(Array)
+          expect(result[0].code).to eq("013455")
+          expect(result[0].prefecture_code).to eq("01")
+          expect(result[0].prefecture).to eq("北海道")
+          expect(result[0].prefecture_kana).to eq("ホッカイドウ")
+          expect(result[0].city).to eq("森町")
+          expect(result[0].city_kana).to eq("モリマチ")
+          expect(result[0].prefecture_capital).to be_falsey
+          expect(result[1].code).to eq("224618")
+          expect(result[1].prefecture_code).to eq("22")
+          expect(result[1].prefecture).to eq("静岡県")
+          expect(result[1].prefecture_kana).to eq("シズオカケン")
+          expect(result[1].city).to eq("森町")
+          expect(result[1].city_kana).to eq("モリマチ")
+          expect(result[1].prefecture_capital).to be_falsey
+        end
+      end
+
+      context "when the result DOES NOT exist" do
+        context "when the condition is NOT match any local governments" do
+          let(:condition) { { prefecture: "東京府" } }
+          it { is_expected.to be_nil }
+        end
+
+        context "when the condition is nil" do
+          let(:condition) { nil }
+          it { is_expected.to be_nil }
+        end
+
+        context "when the condition is NOT a hash" do
+          let(:condition) { "prefecture: 東京都" }
+          it { is_expected.to be_nil }
+        end
+      end
+    end
+
+    context "multiple conditions are specified" do
+      subject(:result) { JpLocalGov.where(condition) }
+      context "when the only one result exists" do
+        let(:condition) { { prefecture: "東京都", prefecture_capital: true } }
+        it "returns a single LocalGov record" do
+          expect(result.code).to eq("131041")
+          expect(result.prefecture_code).to eq("13")
+          expect(result.prefecture).to eq("東京都")
+          expect(result.prefecture_kana).to eq("トウキョウト")
+          expect(result.city).to eq("新宿区")
+          expect(result.city_kana).to eq("シンジュクク")
+          expect(result.prefecture_capital).to be_truthy
+        end
+      end
+
+      context "when the several results exist" do
+        let(:condition) { { city: "森町", city_kana: "モリマチ" } }
+        it "returns Array includes several LocalGov record" do
+          expect(result).to be_a_kind_of(Array)
+          expect(result[0].code).to eq("013455")
+          expect(result[0].prefecture_code).to eq("01")
+          expect(result[0].prefecture).to eq("北海道")
+          expect(result[0].prefecture_kana).to eq("ホッカイドウ")
+          expect(result[0].city).to eq("森町")
+          expect(result[0].city_kana).to eq("モリマチ")
+          expect(result[0].prefecture_capital).to be_falsey
+          expect(result[1].code).to eq("224618")
+          expect(result[1].prefecture_code).to eq("22")
+          expect(result[1].prefecture).to eq("静岡県")
+          expect(result[1].prefecture_kana).to eq("シズオカケン")
+          expect(result[1].city).to eq("森町")
+          expect(result[1].city_kana).to eq("モリマチ")
+          expect(result[1].prefecture_capital).to be_falsey
+        end
+      end
+
+      context "when the result DOES NOT exist" do
+        context "when the condition is NOT match any local governments" do
+          let(:condition) { { city: "千代田区", prefecture_capital: true } }
+          it { is_expected.to be_nil }
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 目的

- Refs: #11 

## やったこと

- プロパティ指定での検索API作成
    - 条件はHashで複数指定することができる
    - 複数値が検索された場合は、配列を返す
    - AND検索のみに対応
- JSONをparseする際に、キーをシンボルにする用に変更

## 申し送り事項

### サンプル

```ruby
>> otaru = JpLocalGov.where(city: "小樽市")
>> hokkaido_capital = JpLocalGov.where(prefecture: otaru.prefecture, prefecture_capital: true).city
#=> "札幌市"
```