### PR TITLE
ActiveRecordに対応させる

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem "rspec", "~> 3.0"
 
 gem "rubocop", "~> 1.7"
 
+gem "activerecord", "~> 6.1.0"
 gem "nokogiri"
 gem "pdf-reader"
 gem "rubocop-fjord"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,10 +7,25 @@ GEM
   remote: https://rubygems.org/
   specs:
     Ascii85 (1.1.0)
+    activemodel (6.1.4.1)
+      activesupport (= 6.1.4.1)
+    activerecord (6.1.4.1)
+      activemodel (= 6.1.4.1)
+      activesupport (= 6.1.4.1)
+    activesupport (6.1.4.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+      zeitwerk (~> 2.3)
     afm (0.2.2)
     ast (2.4.2)
+    concurrent-ruby (1.1.9)
     diff-lcs (1.4.4)
     hashery (2.1.2)
+    i18n (1.8.11)
+      concurrent-ruby (~> 1.0)
+    minitest (5.14.4)
     nokogiri (1.12.5-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.12.5-x86_64-linux)
@@ -18,7 +33,7 @@ GEM
     parallel (1.21.0)
     parser (3.0.3.2)
       ast (~> 2.4.1)
-    pdf-reader (2.6.0)
+    pdf-reader (2.7.0)
       Ascii85 (~> 1.0)
       afm (~> 0.2.1)
       hashery (~> 2.0)
@@ -51,7 +66,7 @@ GEM
       rubocop-ast (>= 1.12.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.14.0)
+    rubocop-ast (1.15.0)
       parser (>= 3.0.1.1)
     rubocop-fjord (0.2.0)
       rubocop (>= 1.0)
@@ -63,7 +78,10 @@ GEM
     ruby-rc4 (0.1.5)
     sqlite3 (1.4.2)
     ttfunk (1.7.0)
+    tzinfo (2.0.4)
+      concurrent-ruby (~> 1.0)
     unicode-display_width (2.1.0)
+    zeitwerk (2.5.1)
 
 PLATFORMS
   x86_64-darwin-19
@@ -71,6 +89,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  activerecord (~> 6.1.0)
   jp_local_gov!
   nokogiri
   pdf-reader

--- a/lib/jp_local_gov.rb
+++ b/lib/jp_local_gov.rb
@@ -2,6 +2,7 @@
 
 require_relative "jp_local_gov/version"
 require_relative "jp_local_gov/local_gov"
+require_relative "jp_local_gov/base"
 require "json"
 
 module JpLocalGov
@@ -10,6 +11,10 @@ module JpLocalGov
   CHECK_BASE = 11
 
   module_function
+
+  def included(model_class)
+    model_class.extend Base
+  end
 
   def find(local_gov_code)
     return nil unless local_gov_code.is_a?(String) && valid_code?(local_gov_code)

--- a/lib/jp_local_gov/base.rb
+++ b/lib/jp_local_gov/base.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require_relative "../jp_local_gov"
+
+module JpLocalGov
+  module Base
+    def jp_local_gov(column_name)
+      define_method "local_government" do
+        JpLocalGov.find(send(column_name))
+      end
+    end
+  end
+end

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# rubocop:disable Metrics/BlockLength
+
+RSpec.describe JpLocalGov::Base do
+  describe "#jp_local_gov" do
+    describe "argument :column_name" do
+      context "when the column_name specified" do
+        let(:model_class) do
+          klass = Class.new(ActiveRecord::Base) do
+            self.table_name = :insurances
+            include JpLocalGov
+            jp_local_gov :local_gov_code
+          end
+          klass.new(local_gov_code: "131016")
+        end
+
+        it "be able to convert local_gov_code" do
+          expect(model_class.local_government.city).to eq "千代田区"
+        end
+      end
+    end
+
+    describe "return value" do
+      let(:klass) do
+        Class.new(ActiveRecord::Base) do
+          self.table_name = :insurances
+          include JpLocalGov
+          jp_local_gov :local_gov_code
+        end
+      end
+
+      context "when the code exists" do
+        let(:model_class) { klass.new(local_gov_code: "131016") }
+        it { expect(model_class).to respond_to(:local_government) }
+        it { expect(model_class.local_government).to be_an_instance_of(JpLocalGov::LocalGov) }
+        it { expect(model_class.local_government.city).to eq "千代田区" }
+      end
+
+      context "when the code DOES NOT exist" do
+        let(:model_class) { klass.new(local_gov_code: "131017") }
+        it { expect(model_class).to respond_to(:local_government) }
+        it { expect(model_class.local_government).to be_nil }
+      end
+    end
+  end
+end
+
+# rubocop:enable Metrics/BlockLength

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require "jp_local_gov"
+require "jp_local_gov/base"
+require "active_record"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
@@ -11,5 +13,29 @@ RSpec.configure do |config|
 
   config.expect_with :rspec do |c|
     c.syntax = :expect
+  end
+
+  config.before(:suite) do
+    setup_db
+  end
+
+  config.after(:suite) do
+    teardown_db
+  end
+end
+
+def setup_db
+  ActiveRecord::Base.establish_connection adapter: "sqlite3", database: ":memory:"
+
+  ActiveRecord::Schema.define(version: 1) do
+    create_table :insurances do |t|
+      t.string :local_gov_code
+    end
+  end
+end
+
+def teardown_db
+  ActiveRecord::Base.connection.tables.each do |table|
+    ActiveRecord::Base.connection.drop_table(table)
   end
 end


### PR DESCRIPTION
## 目的

- Refs: #9

## やったこと

- ActiveRecord::Baseを継承したモデルに対して、当Gemを利用できるようにした。

## 使い方

### インストール

```ruby
gem "jp_local_gov"
```

```shell
bundle install
```

### 使ってみる

```ruby
# app/models/insurances.rb
class Insurances < ActiveRecord::Base
    include JpLocalGov
    jp_local_gov :local_gov_code # DBで設定している地方公共団体コードのカラム名を指定する
end
```

```ruby
# 対象のモデルに対して、local_governmentsというメソッドが追加される
# local_governmentはJpLocalGov::LocalGovのインスタンス
insurances.local_gov_code = "131016"
insurances.local_governments.code = "131016"
insurances.local_governments.city = "千代田区"
```

またGemを追加していれば、通常の特異メソッドも使用可能
```ruby
JpLocalGov.find("131016")
JpLocalGov.where(city: "千代田区")
```