### PR TITLE
JpLocalGov.whereは配列を返すように修正

### DIFF
--- a/lib/jp_local_gov.rb
+++ b/lib/jp_local_gov.rb
@@ -37,7 +37,7 @@ module JpLocalGov
     end.flatten.compact
     return nil if results.empty?
 
-    results.one? ? results.first : results
+    results
   end
 
   def build_local_gov(data, conditions)

--- a/sig/jp_local_gov.rbs
+++ b/sig/jp_local_gov.rbs
@@ -9,7 +9,7 @@ module JpLocalGov
 
   def self?.find: (String local_gov_code) -> (nil | JpLocalGov::LocalGov)
 
-  def self?.where: (Hash[Symbol, untyped] conditions) -> (nil | JpLocalGov::LocalGov | Array[JpLocalGov::LocalGov])
+  def self?.where: (Hash[Symbol, untyped] conditions) -> (nil | Array[JpLocalGov::LocalGov])
 
   def self?.build_local_gov: (Hash[Symbol, untyped] data, Hash[Symbol, String] conditions) -> (nil | Array[JpLocalGov::LocalGov])
 

--- a/spec/jp_local_gov_spec.rb
+++ b/spec/jp_local_gov_spec.rb
@@ -47,14 +47,15 @@ RSpec.describe JpLocalGov do
 
       context "when the only one result exists" do
         let(:condition) { { city: "千代田区" } }
-        it "returns a single LocalGov record" do
-          expect(result.code).to eq("131016")
-          expect(result.prefecture_code).to eq("13")
-          expect(result.prefecture).to eq("東京都")
-          expect(result.prefecture_kana).to eq("トウキョウト")
-          expect(result.city).to eq("千代田区")
-          expect(result.city_kana).to eq("チヨダク")
-          expect(result.prefecture_capital).to be_falsey
+        it "returns Array includes only one LocalGov record" do
+          expect(result).to be_a_kind_of(Array)
+          expect(result[0].code).to eq("131016")
+          expect(result[0].prefecture_code).to eq("13")
+          expect(result[0].prefecture).to eq("東京都")
+          expect(result[0].prefecture_kana).to eq("トウキョウト")
+          expect(result[0].city).to eq("千代田区")
+          expect(result[0].city_kana).to eq("チヨダク")
+          expect(result[0].prefecture_capital).to be_falsey
         end
       end
 
@@ -101,14 +102,15 @@ RSpec.describe JpLocalGov do
       subject(:result) { JpLocalGov.where(condition) }
       context "when the only one result exists" do
         let(:condition) { { prefecture: "東京都", prefecture_capital: true } }
-        it "returns a single LocalGov record" do
-          expect(result.code).to eq("131041")
-          expect(result.prefecture_code).to eq("13")
-          expect(result.prefecture).to eq("東京都")
-          expect(result.prefecture_kana).to eq("トウキョウト")
-          expect(result.city).to eq("新宿区")
-          expect(result.city_kana).to eq("シンジュクク")
-          expect(result.prefecture_capital).to be_truthy
+        it "returns Array includes only one LocalGov record" do
+          expect(result).to be_a_kind_of(Array)
+          expect(result[0].code).to eq("131041")
+          expect(result[0].prefecture_code).to eq("13")
+          expect(result[0].prefecture).to eq("東京都")
+          expect(result[0].prefecture_kana).to eq("トウキョウト")
+          expect(result[0].city).to eq("新宿区")
+          expect(result[0].city_kana).to eq("シンジュクク")
+          expect(result[0].prefecture_capital).to be_truthy
         end
       end
 


### PR DESCRIPTION
## 目的

- Refs: #29 

## やったこと

`JpLocalGov.where`の戻り値は、一件のみの場合に配列ではなく`JpLocalGov::LocalGov`としていたが、戻り値を意識してコードを書く必要があることから、配列に統一した。