### PR TITLE
evalを撤去する

### DIFF
--- a/lib/jp_local_gov.rb
+++ b/lib/jp_local_gov.rb
@@ -42,12 +42,12 @@ module JpLocalGov
 
   def build_local_gov(data, conditions)
     data.values
-        .select { |target| query_builder(target, conditions) }
+        .select { |target| filter(target, conditions) }
         .tap { |result| return nil if result.empty? }
         .map { |result| JpLocalGov::LocalGov.new(result) }
   end
 
-  def query_builder(target, conditions)
+  def filter(target, conditions)
     conditions.map { |condition| target[condition[0]] == condition[1] }.all?
   end
 
@@ -63,6 +63,6 @@ module JpLocalGov
     code[CHECK_DIGITS_INDEX] == check_digits.to_s
   end
 
-  private_class_method :valid_code?, :build_local_gov, :query_builder
+  private_class_method :valid_code?, :build_local_gov, :filter
   private_constant :CHECK_DIGITS_INDEX, :CHECK_BASE
 end

--- a/lib/jp_local_gov.rb
+++ b/lib/jp_local_gov.rb
@@ -48,12 +48,7 @@ module JpLocalGov
   end
 
   def query_builder(target, conditions)
-    condition_stmt = conditions.map.with_index do |condition, index|
-      value = condition[1].is_a?(String) ? "\"#{condition[1]}\"" : (condition[1]).to_s
-      template = "#{target}[:#{condition[0]}] == #{value}"
-      index.zero? ? template : " && #{template}"
-    end.join
-    eval condition_stmt # rubocop:disable Security/Eval
+    conditions.map { |condition| target[condition[0]] == condition[1] }.all?
   end
 
   # Inspect code by check digits defined in JISX0402

--- a/sig/jp_local_gov.rbs
+++ b/sig/jp_local_gov.rbs
@@ -13,7 +13,7 @@ module JpLocalGov
 
   def self?.build_local_gov: (Hash[Symbol, untyped] data, Hash[Symbol, String] conditions) -> (nil | Array[JpLocalGov::LocalGov])
 
-  def self?.query_builder: (Hash[Symbol, untyped] target, Hash[Symbol, String] conditions) -> bool
+  def self?.filter: (Hash[Symbol, untyped] target, Hash[Symbol, String] conditions) -> bool
 
   def self?.valid_code?: (String code) -> bool
 end


### PR DESCRIPTION
## 目的

- Refs: #26 
- evalは脆弱性を含み、かつ修正箇所ではevalを使用しないコードにリファクタリングできるため、evalを除去する。