### PR TITLE
Feature: add lint and test setting

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,14 @@ Style/StringLiteralsInInterpolation:
   Enabled: true
   EnforcedStyle: double_quotes
 
+Metrics/BlockLength:
+  Exclude:
+    - spec/**/*
+
+Metrics/ClassLength:
+  Exclude:
+    - spec/**/*
+
 Layout/LineLength:
   Max: 120
 

--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,8 @@ group :development do
   gem "rbs"
   gem "rubocop"
   gem "rubocop-fjord"
+  gem "rubocop-rake"
+  gem "rubocop-rspec"
   gem "sqlite3"
   gem "steep"
 end

--- a/README.md
+++ b/README.md
@@ -155,6 +155,22 @@ end
 | `bin/lint`         | Run Rubocop                                                                                              |
 | `bin/steep`        | Run `steep stats` and `steep check`                                                                      |
 
+### Running Test via JetBrains IDE (e.g. RubyMine)
+
+This gem use 'Appraisal' to inspect several versions of Rails.
+
+So you should run rspec by `bundle exec appraisal rspec` and you won't be able to run spec via IDE (only run via your terminal).
+
+If you use JetBrains IDE and you want to run spec via IDE, try to configure the following steps.
+
+1. Open 「Edit Configurations...」
+2. Open 「Edit Configuration templates...」
+3. Select 「RSpec」
+4. Check 「Use custom RSpec runner script:」 ans fill the script with `[CLONE_DIR]/bin/spec_runner.rb`
+5. Click「APPLY」, then you can run spec via IDE!!🎉
+
+If you have already run spec via IDE before configuration, delete the existing configuration and try to configure the above steps
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/IkumaTadokoro/jp_local_gov. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/IkumaTadokoro/jp_local_gov/blob/main/CODE_OF_CONDUCT.md).

--- a/bin/spec_runner.rb
+++ b/bin/spec_runner.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# !/usr/bin/env ruby
+
+# Most of the code here is copied from /lib/appraisal/cli.rb in the appraisal gem library
+require "rubygems"
+require "bundler/setup"
+require "appraisal"
+require "appraisal/cli"
+
+begin
+  `bundle exec appraisal list`.split(/\R/) do |appraisal_name|
+    cmd = [appraisal_name, "rspec"] + ARGV
+    Appraisal::CLI.start(cmd)
+  end
+rescue Appraisal::AppraisalsNotFound => e
+  puts e.message
+  exit 127
+end

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/BlockLength
-
 RSpec.describe JpLocalGov::Base do
   describe "#jp_local_gov" do
     describe "argument :column_name" do
@@ -45,5 +43,3 @@ RSpec.describe JpLocalGov::Base do
     end
   end
 end
-
-# rubocop:enable Metrics/BlockLength

--- a/spec/jp_local_gov_spec.rb
+++ b/spec/jp_local_gov_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/BlockLength
-
 RSpec.describe JpLocalGov do
   describe ".find" do
     context "the local government code is specified" do
@@ -144,5 +142,3 @@ RSpec.describe JpLocalGov do
     end
   end
 end
-
-# rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
- style: Add rubocop-rake and rubocop-rspec
- style: Remove Mertics rule for spec
- chore: Add RSpec Runner for JetBrains IDE 
    - JetBrains IDE can run the individual or all specs via GUI
    - This Gem use "Appraisal", so this function is invalid
    - Add and configure this script, you can run rspec via Appraisal and GUI