### PR TITLE
fix: Fix a task(`jp_local_gov:data:update_all`)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 /doc/
 /pkg/
 /spec/reports/
-/tmp/
 vendor/bundle
 
 # rspec failure tracking

--- a/tmp/.gitignore
+++ b/tmp/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
- The rake task `jp_local_gov:data:update_all` was failed with `SQLite3::CantOpenException: unable to open database file`
- This PR fixes a cause of above error by making tmp directory used by task

Fixes: #60