### PR TITLE
feat: Add JpLocalGov::Random module

### DIFF
--- a/lib/jp_local_gov/random.rb
+++ b/lib/jp_local_gov/random.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require_relative "../jp_local_gov"
+
+module JpLocalGov
+  module Random
+    DATA_DIR = "#{File.dirname(__FILE__)}/../../data/json/".freeze
+    RANDOMIZE_TARGET = %w[code city city_kana prefecture prefecture_code prefecture_kana].freeze
+
+    module_function
+
+    RANDOMIZE_TARGET.each do |target|
+      define_method target.to_s do
+        sample_data.send(target)
+      end
+    end
+
+    def sample_data
+      file_name = ("1".."47").to_a.sample&.rjust(2, "0")
+      json_file = "#{DATA_DIR}#{file_name}.json"
+      data = JSON.parse(File.read(json_file), { symbolize_names: true })
+      JpLocalGov::LocalGov.new(data[data.keys.sample])
+    end
+
+    private_class_method :sample_data
+    private_constant :DATA_DIR, :RANDOMIZE_TARGET
+  end
+end

--- a/sig/jp_local_gov/random.rbs
+++ b/sig/jp_local_gov/random.rbs
@@ -1,0 +1,9 @@
+module JpLocalGov
+  module Random
+    DATA_DIR: String
+
+    RANDOMIZE_TARGET: Array[String]
+
+    def self?.sample_data: () -> JpLocalGov::LocalGov
+  end
+end

--- a/spec/random_spec.rb
+++ b/spec/random_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+RSpec.describe JpLocalGov::Random do
+  describe ".code" do
+    let!(:code) { JpLocalGov::Random.code }
+    it "returns valid random code" do
+      expect(code).to be_a_kind_of String
+      expect(JpLocalGov.valid_code?(code)).to be_truthy
+    end
+  end
+
+  describe ".city" do
+    let!(:city) { JpLocalGov::Random.city }
+    it "returns existing city name " do
+      expect(city).to be_a_kind_of String
+      expect(JpLocalGov.where(city: city).map(&:city)).to include city
+    end
+  end
+
+  describe ".city_kana" do
+    let!(:city_kana) { JpLocalGov::Random.city_kana }
+    it "returns existing city name(kana)" do
+      expect(city_kana).to be_a_kind_of String
+      expect(JpLocalGov.where(city_kana: city_kana).map(&:city_kana)).to include city_kana
+    end
+  end
+
+  describe ".prefecture_code" do
+    let!(:prefecture_code) { JpLocalGov::Random.prefecture_code }
+    it "returns existing prefecture_code" do
+      expect(prefecture_code).to be_a_kind_of String
+      expect(JpLocalGov.where(prefecture_code: prefecture_code).map(&:prefecture_code)).to include prefecture_code
+    end
+  end
+
+  describe ".prefecture" do
+    let!(:prefecture) { JpLocalGov::Random.prefecture }
+    it "returns existing prefecture" do
+      expect(prefecture).to be_a_kind_of String
+      expect(JpLocalGov.where(prefecture: prefecture).map(&:prefecture)).to include prefecture
+    end
+  end
+
+  describe ".prefecture_kana" do
+    let!(:prefecture_kana) { JpLocalGov::Random.prefecture_kana }
+    it "returns existing prefecture_kana" do
+      expect(prefecture_kana).to be_a_kind_of String
+      expect(JpLocalGov.where(prefecture_kana: prefecture_kana).map(&:prefecture_kana)).to include prefecture_kana
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 
 require "jp_local_gov"
 require "jp_local_gov/base"
+require "jp_local_gov/random"
 require "active_record"
 
 RSpec.configure do |config|


### PR DESCRIPTION
## Summary

This PR adds `JpLocalGov::Random` module to create sample test data
Local government code is not cannot be a random number
It must satisfy the check digit
This limitation makes it difficult to create test data randomly.

This feature will come in handy when writing data　independent FactoryBot

## Usage

```ruby
JpLocalGov::Random.code
#=> "131016"

JpLocalGov::Random.city
#=> "札幌市"
```

Closes: #65