### PR TITLE
feat: Add JpLocalGov.all_xxx

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,15 @@ The following attributes can be specified for the condition.
 | city_kana          | String        | "チヨダク"   |
 | prefecture_capital | true or false | false    |
 
+### All data
+
+You can get all local governments using `JpLocalGov.all`
+
+```ruby
+JpLocalGov.all
+# =>  [#<JpLocalGov::LocalGov:0x00007fdf3a9c6758 @code="011002", @prefecture_code="01", @prefecture="北海道", @prefecture_kana="ホッカイドウ", @city="札幌市na="サッポロシ", @prefecture_capital=true>, #<JpLocalGov::LocalGov:0x00007fdf3a9c6730 @code="011011",...
+```
+
 ### Usage on Rails (ActiveRecord)
 
 Include JpLocalGov to Model which ActiveRecord::Base inherited.
@@ -155,6 +164,14 @@ end
 
 This method inspect code by [check digits defined in JISX0402](https://www.soumu.go.jp/main_content/000137948.pdf).
 (And also check code is String.)
+
+### View Template
+
+Use `collection_select` to generate selector in view:
+
+```ruby
+f.collection_select :local_gov_code, JpLocalGov.all, :code, :city # e.g. code: 131016, city: "千代田区"
+```
 
 ## Development
 

--- a/lib/jp_local_gov.rb
+++ b/lib/jp_local_gov.rb
@@ -34,7 +34,7 @@ module JpLocalGov
 
     json_files = prefecture_code_list.map { "#{DATA_DIR}#{_1}.json" }
     results = json_files.map do |json_file|
-      data = JSON.parse(File.open(json_file).read, { symbolize_names: true })
+      data = JSON.parse(File.read(json_file), { symbolize_names: true })
       build_local_gov(data, conditions)
     end.flatten.compact
     return nil if results.empty?
@@ -56,6 +56,14 @@ module JpLocalGov
     candidate = (CHECK_BASE - sub_total % CHECK_BASE) % 10
     check_digits = sub_total > CHECK_BASE ? candidate : CHECK_BASE - sub_total
     code[CHECK_DIGITS_INDEX] == check_digits.to_s
+  end
+
+  def all
+    json_files = prefecture_code_list.map { "#{DATA_DIR}#{_1}.json" }
+    json_files.flat_map do |json_file|
+      data = JSON.parse(File.read(json_file), { symbolize_names: true })
+      data.values.map { |value| JpLocalGov::LocalGov.new(value) }
+    end
   end
 
   def build_local_gov(data, conditions)

--- a/sig/jp_local_gov.rbs
+++ b/sig/jp_local_gov.rbs
@@ -15,11 +15,13 @@ module JpLocalGov
 
   def self?.where: (Hash[Symbol, untyped] conditions) -> (nil | Array[JpLocalGov::LocalGov])
 
+  def self?.valid_code?: (String code) -> bool
+
+  def self.all: () -> Array[JpLocalGov::LocalGov]
+
   def self?.build_local_gov: (Hash[Symbol, untyped] data, Hash[Symbol, String] conditions) -> (nil | Array[JpLocalGov::LocalGov])
 
   def self?.filter: (Hash[Symbol, untyped] target, Hash[Symbol, String] conditions) -> bool
-
-  def self?.valid_code?: (String code) -> bool
 
   def prefecture_code_list: () -> Array[String]
 end

--- a/spec/jp_local_gov_spec.rb
+++ b/spec/jp_local_gov_spec.rb
@@ -142,9 +142,8 @@ RSpec.describe JpLocalGov do
     end
   end
 
-  describe "#valid_code?" do
+  describe ".valid_code?" do
     subject(:result) { JpLocalGov.valid_code?(code) }
-
     context "when the valid local_gov_code is specified" do
       let(:code) { "011002" }
       it { is_expected.to be_truthy }
@@ -181,6 +180,20 @@ RSpec.describe JpLocalGov do
           end
         end
       end
+    end
+  end
+
+  describe ".all" do
+    let!(:result) { JpLocalGov.all }
+    it "has all attributes of LocalGov" do
+      expect(result).to be_a_kind_of Array
+      expect(result).to all(respond_to(:code,
+                                       :city,
+                                       :city_kana,
+                                       :prefecture_code,
+                                       :prefecture,
+                                       :prefecture_kana,
+                                       :prefecture_capital))
     end
   end
 end


### PR DESCRIPTION
This PR adds `JpLocalGov.all which returns all local governments
This method is expected to use in Rails app, especially VIEW

## Usage

```ruby
JpLocalGov.all
# => [#<JpLocalGov::LocalGov:0x00007fdf3a9c6758 @code="011002",@prefecture_code="01", @prefecture="北海道", @prefecture_kana="ホッカイドウ",@city="札幌市na="サッポロシ", @prefecture_capital=true>,#<JpLocalGov::LocalGov:0x00007fdf3a9c6730 @code="011011",
```

In Rails app, you can use as an object for `collection_select`

```ruby
f.collection_select :local_gov_code, JpLocalGov.all, :code, :city
```

Closes: #54