### PR TITLE
fix: Fix dependency of JpLocalGov::Random

### DIFF
--- a/lib/jp_local_gov.rb
+++ b/lib/jp_local_gov.rb
@@ -3,6 +3,7 @@
 require_relative "jp_local_gov/version"
 require_relative "jp_local_gov/local_gov"
 require_relative "jp_local_gov/base"
+require_relative "jp_local_gov/random"
 require "json"
 
 module JpLocalGov


### PR DESCRIPTION
Fix the dependency of JpLocalGov::Random
JpLocalGov::Random is not running properly because this module was not
required by `jp_local_gov.rb`

Add require to `jp_local_gov.rb`

Closes: #70