### PR TITLE
Support running workflow with matrix ruby ver

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,12 +9,15 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        ruby: [3.0, 3.1]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
+          ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
 
       - name: Rubocop

--- a/.github/workflows/steep.yml
+++ b/.github/workflows/steep.yml
@@ -10,10 +10,14 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby: [3.0, 3.1]
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
         with:
+          ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
       - run: bundle exec appraisal install
       - run: |
@@ -21,10 +25,14 @@ jobs:
         shell: bash
   stats:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby: [3.0, 3.1]
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
         with:
+          ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
       - run: bundle exec appraisal install
       - run: bundle exec rake steep:stats

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,12 +9,15 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        ruby: [3.0, 3.1]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
+          ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
       - run: bundle exec appraisal install
       - run: bundle exec appraisal rspec


### PR DESCRIPTION
There is a need to specify ruby version in workflow settings to remove `.ruby-version`

Refs: #77