### PR TITLE
Fix test ci name

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
     branches: ["main"]
 
 jobs:
-  lint:
+  test:
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
Test ci name has become `lint` now `test` is right name and I fixed this Closes: #80