### PR TITLE
Fix JpLocalGov.valid_code?'s condition

### DIFF
--- a/lib/jp_local_gov.rb
+++ b/lib/jp_local_gov.rb
@@ -55,7 +55,7 @@ module JpLocalGov
                     .map.with_index { |digit, index| digit.to_i * (CHECK_DIGITS_INDEX - index + 1) }
                     .sum
     candidate = (CHECK_BASE - sub_total % CHECK_BASE) % 10
-    check_digits = sub_total > CHECK_BASE ? candidate : CHECK_BASE - sub_total
+    check_digits = sub_total >= CHECK_BASE ? candidate : CHECK_BASE - sub_total
     code[CHECK_DIGITS_INDEX] == check_digits.to_s
   end
 

--- a/spec/jp_local_gov_spec.rb
+++ b/spec/jp_local_gov_spec.rb
@@ -145,8 +145,21 @@ RSpec.describe JpLocalGov do
   describe ".valid_code?" do
     subject(:result) { JpLocalGov.valid_code?(code) }
     context "when the valid local_gov_code is specified" do
-      let(:code) { "011002" }
-      it { is_expected.to be_truthy }
+      # sub_total is the sum of the first through fifth digits multiplied by 6.5.4.3.2, respectively.
+      context "when the sub total is under 11" do
+        let(:code) { "011002" }
+        it { is_expected.to be_truthy }
+      end
+
+      context "when the sub total is 11" do
+        let(:code) { "011011" }
+        it { is_expected.to be_truthy }
+      end
+
+      context "when the sub total is over 11" do
+        let(:code) { "011096" }
+        it { is_expected.to be_truthy }
+      end
     end
 
     context "when the INVALID local_gov_code is specified" do


### PR DESCRIPTION
JpLocalGov.valid_code? evaluates the check digit based on the specifications of JISX402.

If the subtotal (the sum of the first through fifth digits multiplied by 6.5.4.3.2 respectively) is less than 11,
the check digit is `11 minus the subtotal` in JISX0402.

The code before returns `11 minus the subtotal` even when the subtotal was just 11, so I fixed conditions.

Closes: #85