### PR TITLE
ci: remove steep stats

### DIFF
--- a/.github/workflows/steep.yml
+++ b/.github/workflows/steep.yml
@@ -23,16 +23,3 @@ jobs:
       - run: |
           bundle exec steep check | ruby -pe 'sub(/^(.+):(\d+):(\d+): (.+)$/, %q{::error file=\1,line=\2,col=\3::\4})'
         shell: bash
-  stats:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        ruby: [2.7, '3.0', 3.1]
-    steps:
-      - uses: actions/checkout@v2
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ matrix.ruby }}
-          bundler-cache: true
-      - run: bundle exec appraisal install
-      - run: bundle exec rake steep:stats


### PR DESCRIPTION
Developers see steep stats in CI and do nothing.
Remove steep: stats from CI because it will only increase the execution time of the CI.
However, Rake task is left so that it can be executed individually

Closes: #84