### PR TITLE
fix: convert nilable argument into String

### DIFF
--- a/Steepfile
+++ b/Steepfile
@@ -3,4 +3,6 @@
 target :lib do
   check "lib"
   signature "sig"
+
+  library "json"
 end

--- a/lib/jp_local_gov.rb
+++ b/lib/jp_local_gov.rb
@@ -46,7 +46,7 @@ module JpLocalGov
   # Inspect code by check digits defined in JISX0402
   # https://www.soumu.go.jp/main_content/000137948.pdf
   def valid_code?(code)
-    unless code.is_a?(String) && code.length == VALID_CODE_LENGTH && prefecture_code_list.include?(code[0..1])
+    unless code.is_a?(String) && code.length == VALID_CODE_LENGTH && prefecture_code_list.include?(code[0..1].to_s)
       return false
     end
 


### PR DESCRIPTION
JpLocalGov.valid_code?' s argument expect String. There is a case nil is passed to this method.

When nil is passed, first condition `is_a?(String)` return false and short circuit don't execute after this, so behavior is good.

However RBS output following error and this pr fixed this.

```
Cannot pass a value of type `(::String | nil)` as an argument of type `::String`
```